### PR TITLE
Non latin characters in filenames and paths

### DIFF
--- a/src/NodeAdapter.cpp
+++ b/src/NodeAdapter.cpp
@@ -239,7 +239,7 @@ void NodeAdapter::deinit() {
 CryptoNote::CoreConfig NodeAdapter::makeCoreConfig() const {
   CryptoNote::CoreConfig config;
   boost::program_options::variables_map options;
-  boost::any dataDir = Settings::instance().getDataDir().absolutePath().toStdString();
+  boost::any dataDir = std::string(Settings::instance().getDataDir().absolutePath().toLocal8Bit().data());
   options.insert(std::make_pair("data-dir", boost::program_options::variable_value(dataDir, false)));
   config.init(options);
   return config;
@@ -252,7 +252,7 @@ CryptoNote::NetNodeConfig NodeAdapter::makeNetNodeConfig() const {
   boost::any p2pBindPort = static_cast<uint16_t>(Settings::instance().getP2pBindPort());
   boost::any p2pExternalPort = static_cast<uint16_t>(Settings::instance().getP2pExternalPort());
   boost::any p2pAllowLocalIp = Settings::instance().hasAllowLocalIpOption();
-  boost::any dataDir = Settings::instance().getDataDir().absolutePath().toStdString();
+  boost::any dataDir = std::string(Settings::instance().getDataDir().absolutePath().toLocal8Bit().data());
   boost::any hideMyPort = Settings::instance().hasHideMyPortOption();
   options.insert(std::make_pair("p2p-bind-ip", boost::program_options::variable_value(p2pBindIp, false)));
   options.insert(std::make_pair("p2p-bind-port", boost::program_options::variable_value(p2pBindPort, false)));

--- a/src/WalletAdapter.cpp
+++ b/src/WalletAdapter.cpp
@@ -511,7 +511,11 @@ void WalletAdapter::unlock() {
 
 bool WalletAdapter::openFile(const QString& _file, bool _readOnly) {
   lock();
+#ifdef Q_OS_WIN
+  m_file.open(_file.toStdWString(), std::ios::binary | (_readOnly ? std::ios::in : (std::ios::out | std::ios::trunc)));
+#else
   m_file.open(_file.toStdString(), std::ios::binary | (_readOnly ? std::ios::in : (std::ios::out | std::ios::trunc)));
+#endif
   if (!m_file.is_open()) {
     unlock();
   }


### PR DESCRIPTION
Severe bug fix for Windows - allows to open wallet files with names and
paths containing cyrillic and other non latin characters and makes
wallet working if username contains non latin characters.

We use some code from your excellent wallet. It's time to give back.